### PR TITLE
Be compatible with yesod-1.4

### DIFF
--- a/Yesod/Auth/BCrypt.hs
+++ b/Yesod/Auth/BCrypt.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE CPP                        #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
 -------------------------------------------------------------------------------
 -- |
 -- Module      :  Yesod.Auth.BCrypt
@@ -65,8 +66,7 @@ module Yesod.Auth.BCrypt
     , authHashDB
     , getAuthIdHashDB
       -- * Predefined data type
-    , Siteuser
-    , SiteuserGeneric (..)
+    , Siteuser (..)
     , SiteuserId
     , EntityField (..)
     , migrateSiteusers
@@ -122,11 +122,10 @@ setPassword pwd u = do
 -- | Given a user ID and password in plaintext, validate them against
 --   the database values.
 validateUser :: ( YesodPersist yesod
-                , b ~ YesodPersistBackend yesod
-                , PersistMonadBackend (b (HandlerT yesod IO)) ~ PersistEntityBackend siteuser
-                , PersistUnique (b (HandlerT yesod IO))
                 , PersistEntity siteuser
                 , HashDBUser    siteuser
+                , PersistEntityBackend siteuser ~ YesodPersistBackend yesod
+                , PersistUnique (YesodPersistBackend yesod)
                 ) => 
                 Unique siteuser     -- ^ User unique identifier
              -> Text            -- ^ Password in plaint-text
@@ -148,9 +147,8 @@ login = PluginR "hashdb" ["login"]
 --   username (whatever it might be) to unique user ID.
 postLoginR :: ( YesodAuth y, YesodPersist y
               , HashDBUser siteuser, PersistEntity siteuser
-              , b ~ YesodPersistBackend y
-              , PersistMonadBackend (b (HandlerT y IO)) ~ PersistEntityBackend siteuser
-              , PersistUnique (b (HandlerT y IO))
+              , PersistEntityBackend siteuser ~ YesodPersistBackend y
+              , PersistUnique (YesodPersistBackend y)
               )
            => (Text -> Maybe (Unique siteuser))
            -> HandlerT Auth (HandlerT y IO) TypedContent
@@ -173,9 +171,8 @@ postLoginR uniq = do
 getAuthIdHashDB :: ( YesodAuth master, YesodPersist master
                    , HashDBUser siteuser, PersistEntity siteuser
                    , Key siteuser ~ AuthId master
-                   , b ~ YesodPersistBackend master
-                   , PersistMonadBackend (b (HandlerT master IO)) ~ PersistEntityBackend siteuser
-                   , PersistUnique (b (HandlerT master IO))
+                   , PersistEntityBackend siteuser ~ YesodPersistBackend master
+                   , PersistUnique (YesodPersistBackend master)
                    )
                 => (AuthRoute -> Route master)   -- ^ your site's Auth Route
                 -> (Text -> Maybe (Unique siteuser)) -- ^ gets user ID
@@ -202,9 +199,9 @@ getAuthIdHashDB authR uniq creds = do
 authHashDB :: ( YesodAuth m, YesodPersist m
               , HashDBUser siteuser
               , PersistEntity siteuser
-              , b ~ YesodPersistBackend m
-              , PersistMonadBackend (b (HandlerT m IO)) ~ PersistEntityBackend siteuser
-              , PersistUnique (b (HandlerT m IO)))
+              , PersistEntityBackend siteuser ~ YesodPersistBackend m
+              , PersistUnique (YesodPersistBackend m)
+              )
            => (Text -> Maybe (Unique siteuser)) -> AuthPlugin m
 authHashDB uniq = AuthPlugin "hashdb" dispatch $ \tm -> toWidget [hamlet|
 $newline never
@@ -243,6 +240,6 @@ Siteuser
     deriving Typeable
 |]
 
-instance HashDBUser (SiteuserGeneric backend) where
+instance HashDBUser Siteuser where
   siteuserPasswordHash = Just . siteuserPassword
   setSaltAndPasswordHash h u = u { siteuserPassword = h }

--- a/Yesod/Auth/BCrypt.hs
+++ b/Yesod/Auth/BCrypt.hs
@@ -10,8 +10,8 @@
 {-# LANGUAGE CPP                        #-}
 -------------------------------------------------------------------------------
 -- |
--- Module      :  Yesod.Auth.HashDB
--- Copyright   :  (c) Patrick Brisbin 2010 
+-- Module      :  Yesod.Auth.BCrypt
+-- Copyright   :  (c) Patrick Brisbin 2010
 -- License     :  as-is
 --
 -- Maintainer  :  pbrisbin@gmail.com
@@ -19,7 +19,7 @@
 -- Portability :  Portable
 --
 -- A yesod-auth AuthPlugin designed to look users up in Persist where
--- their user id's and a Bcrypt hash + salt of their password is stored.
+-- their user ID and a Bcrypt hash + salt of their password is stored.
 --
 -- Example usage:
 --
@@ -76,18 +76,14 @@ import Yesod.Persist
 import Yesod.Form
 import Yesod.Auth
 import Yesod.Core
-import Text.Hamlet (hamlet)
 
 import Control.Applicative         ((<$>), (<*>))
-import Control.Monad               (replicateM,liftM)
 import Data.Typeable
 
-import qualified Data.ByteString.Lazy.Char8 as LBS (pack, unpack)
 import qualified Data.ByteString.Char8 as BS (pack, unpack)
 import Crypto.BCrypt
-import Data.Text                   (Text, pack, unpack, append)
+import Data.Text                   (Text, pack, unpack)
 import Data.Maybe                  
-import System.Random               (randomRIO)
 import Prelude
 -- | Interface for data type which holds user info. It's just a
 --   collection of getters and setters
@@ -198,7 +194,7 @@ getAuthIdHashDB authR uniq creds = do
                 -- user exists
                 Just (Entity uid _) -> return $ Just uid
                 Nothing       -> do
-                  loginErrorMessage (authR LoginR) "User not found"
+                  _ <- loginErrorMessage (authR LoginR) "User not found"
                   return Nothing
 
 -- | Prompt for username and password, validate that against a database

--- a/yesod-auth-bcrypt.cabal
+++ b/yesod-auth-bcrypt.cabal
@@ -14,46 +14,17 @@ description:     BCrypt salted and hashed passwords in a database as auth for ye
 
 library
     build-depends:   base                    >= 4         && < 5
-                   , authenticate            >= 1.3
-                   , bytestring              >= 0.9.1.4
+                   , bytestring              >= 0.9.1.4   && < 0.11
                    , yesod-core              >= 1.2       && < 1.3
-                   , wai                     >= 1.4
-                   , template-haskell
-                   , pureMD5                 >= 2.0
-                   , random                  >= 1.0.0.2
-                   , text                    >= 0.7
-                   , mime-mail               >= 0.3
-                   , yesod-persistent        >= 1.2
-                   , hamlet                  >= 1.1       && < 1.3
-                   , shakespeare              >= 2.0       && < 2.1
-                   , shakespeare-css         >= 1.0       && < 1.2
-                   , shakespeare-js          >= 1.0.2     && < 1.4
-                   , containers
-                   , unordered-containers
+                   , text                    >= 0.7       && < 1.2
+                   , yesod-persistent        >= 1.2       && < 1.3
                    , yesod-form              >= 1.3       && < 1.4
-                   , transformers            >= 0.2.2
-                   , persistent              >= 1.2       && < 1.4
-                   , persistent-template     >= 1.2       && < 1.4
-                   , http-conduit            >= 1.5
-                   , aeson                   >= 0.5
-                   , pwstore-fast            >= 2.2
-                   , lifted-base             >= 0.1
-                   , blaze-html              >= 0.5
-                   , blaze-markup            >= 0.5.1
-                   , network
-                   , http-types
-                   , file-embed
-                   , email-validate          >= 1.0
-                   , data-default
-                   , resourcet
-                   , safe
-                   , time
-                   , yesod-auth
-                   , bcrypt
+                   , yesod-auth              >= 1.3       && < 1.4
+                   , bcrypt                  >= 0.0.4     && < 0.1
 
     exposed-modules: Yesod.Auth.BCrypt
     ghc-options:     -Wall
 
 source-repository head
   type:     git
-  location: https://github.com/yesodweb/yesod
+  location: https://github.com/TobyGoodwin/yesod-auth-bcrypt

--- a/yesod-auth-bcrypt.cabal
+++ b/yesod-auth-bcrypt.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth-bcrypt
-version:         0.1.1
+version:         0.2.0
 license:         MIT
 license-file:    LICENSE
 author:          Oliver Hunt

--- a/yesod-auth-bcrypt.cabal
+++ b/yesod-auth-bcrypt.cabal
@@ -15,11 +15,11 @@ description:     BCrypt salted and hashed passwords in a database as auth for ye
 library
     build-depends:   base                    >= 4         && < 5
                    , bytestring              >= 0.9.1.4   && < 0.11
-                   , yesod-core              >= 1.2       && < 1.3
-                   , text                    >= 0.7       && < 1.2
-                   , yesod-persistent        >= 1.2       && < 1.3
-                   , yesod-form              >= 1.3       && < 1.4
-                   , yesod-auth              >= 1.3       && < 1.4
+                   , yesod-core              >= 1.4       && < 1.5
+                   , text                    >= 0.7       && < 1.3
+                   , yesod-persistent        >= 1.4       && < 1.5
+                   , yesod-form              >= 1.4       && < 1.5
+                   , yesod-auth              >= 1.4       && < 1.5
                    , bcrypt                  >= 0.0.4     && < 0.1
 
     exposed-modules: Yesod.Auth.BCrypt

--- a/yesod-auth-bcrypt.cabal
+++ b/yesod-auth-bcrypt.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth-bcrypt
-version:         0.1.0
+version:         0.1.1
 license:         MIT
 license-file:    LICENSE
 author:          Oliver Hunt


### PR DESCRIPTION
Hi Ollie,

@CindyLinz kindly sent me a PR to make yesod-auth-bcrypt compatible with yesod 1.4. I've confirmed that it builds, and added it to my fork. (Annoyingly I'm having trouble converting my major yesod app to -1.4, and don't have time right now to run up a test project, so I can't claim to have tested these changes properly, but they look reasonably sane.)

Any chance you could get these merged, and a new version uploaded to hackage?

Thanks,

Toby.

P.S. I'm very much a novice github user, so if I've made any elementary mistakes please be patient with me!